### PR TITLE
feat: create `rehype-harden` and use it in `harden-react-markdown`

### DIFF
--- a/harden-react-markdown/package.json
+++ b/harden-react-markdown/package.json
@@ -36,6 +36,9 @@
     "react": ">=16.8.0",
     "react-markdown": ">=9.0.0"
   },
+  "dependencies": {
+    "rehype-harden": "file:../rehype-harden"
+  },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.4",
     "@testing-library/react": "^16.3.0",

--- a/harden-react-markdown/pnpm-lock.yaml
+++ b/harden-react-markdown/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      rehype-harden:
+        specifier: file:../rehype-harden
+        version: file:../rehype-harden
     devDependencies:
       '@testing-library/jest-dom':
         specifier: ^6.6.4
@@ -989,6 +993,9 @@ packages:
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
+
+  rehype-harden@file:../rehype-harden:
+    resolution: {directory: ../rehype-harden, type: directory}
 
   remark-parse@11.0.0:
     resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
@@ -2280,6 +2287,8 @@ snapshots:
     dependencies:
       indent-string: 4.0.0
       strip-indent: 3.0.0
+
+  rehype-harden@file:../rehype-harden: {}
 
   remark-parse@11.0.0:
     dependencies:

--- a/harden-react-markdown/src/index.tsx
+++ b/harden-react-markdown/src/index.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { ComponentType, ComponentProps, createElement } from "react";
-import type { Components, Options } from "react-markdown";
+import { ComponentType, ComponentProps } from "react";
+import type { Options } from "react-markdown";
+import { harden } from "rehype-harden";
 
 interface HardenReactMarkdownOptions {
   defaultOrigin?: string;
@@ -9,199 +10,27 @@ interface HardenReactMarkdownOptions {
   allowedImagePrefixes?: string[];
 }
 
-// Ensure component accepts Options and extract its exact prop type
-type MarkdownComponentProps<T extends ComponentType<Options>> =
-  ComponentProps<T>;
-
-// Strict validation that component props are compatible with Options
-type ValidateMarkdownComponent<T extends ComponentType<Options>> =
-  ComponentProps<T> extends Options ? T : never;
-
-// Enhanced constraint ensuring the component is both Options-compatible and JSX-renderable
-type StrictMarkdownComponent<T extends ComponentType<Options>> =
-  T extends ComponentType<infer P>
-    ? P extends Options
-      ? ValidateMarkdownComponent<T>
-      : never
-    : never;
-
-export default function hardenReactMarkdown<
-  TMarkdownComponent extends ComponentType<Options>,
->(
-  MarkdownComponent: StrictMarkdownComponent<TMarkdownComponent>,
-): ComponentType<
-  MarkdownComponentProps<TMarkdownComponent> & HardenReactMarkdownOptions
-> {
-  return function HardenedReactMarkdown(
-    props: MarkdownComponentProps<TMarkdownComponent> &
-      HardenReactMarkdownOptions,
-  ) {
-    const {
-      defaultOrigin = "",
-      allowedLinkPrefixes = [],
-      allowedImagePrefixes = [],
-      components: userComponents,
-      ...reactMarkdownProps
-    } = props;
-    // Only require defaultOrigin if we have specific prefixes (not wildcard only)
-    const hasSpecificLinkPrefixes =
-      allowedLinkPrefixes.length &&
-      !allowedLinkPrefixes.every((p) => p === "*");
-    const hasSpecificImagePrefixes =
-      allowedImagePrefixes.length &&
-      !allowedImagePrefixes.every((p) => p === "*");
-
-    if (
-      !defaultOrigin &&
-      (hasSpecificLinkPrefixes || hasSpecificImagePrefixes)
-    ) {
-      throw new Error(
-        "defaultOrigin is required when allowedLinkPrefixes or allowedImagePrefixes are provided",
-      );
-    }
-
-    const parseUrl = (url: unknown): URL | null => {
-      if (typeof url !== "string") return null;
-      try {
-        // Try to parse as absolute URL first
-        const urlObject = new URL(url);
-        return urlObject;
-      } catch (error) {
-        // If that fails and we have a defaultOrigin, try with it
-        if (defaultOrigin) {
-          try {
-            const urlObject = new URL(url, defaultOrigin);
-            return urlObject;
-          } catch (error) {
-            return null;
-          }
-        }
-        return null;
-      }
-    };
-
-    const isPathRelativeUrl = (url: unknown): boolean => {
-      if (typeof url !== "string") return false;
-      return url.startsWith("/");
-    };
-
-    const transformUrl = (
-      url: unknown,
-      allowedPrefixes: string[],
-    ): string | null => {
-      if (!url) return null;
-      const parsedUrl = parseUrl(url);
-      if (!parsedUrl) return null;
-
-      // If the input is path relative, we output a path relative URL as well,
-      // however, we always run the same checks on an absolute URL and we
-      // always rescronstruct the output from the parsed URL to ensure that
-      // the output is always a valid URL.
-      const inputWasRelative = isPathRelativeUrl(url);
-      const urlString = parseUrl(url);
-      if (
-        urlString &&
-        allowedPrefixes.some((prefix) => {
-          const parsedPrefix = parseUrl(prefix);
-          if (!parsedPrefix) {
-            return false;
-          }
-          if (parsedPrefix.origin !== urlString.origin) {
-            return false;
-          }
-          return urlString.href.startsWith(parsedPrefix.href);
-        })
-      ) {
-        if (inputWasRelative) {
-          return urlString.pathname + urlString.search + urlString.hash;
-        }
-        return urlString.href;
-      }
-      // Check for wildcard - allow all URLs
-      if (allowedPrefixes.includes("*")) {
-        // Wildcard only allows http and https URLs
-        if (parsedUrl.protocol !== "https:" && parsedUrl.protocol !== "http:") {
-          return null;
-        }
-        const inputWasRelative = isPathRelativeUrl(url);
-        if (parsedUrl) {
-          if (inputWasRelative) {
-            return parsedUrl.pathname + parsedUrl.search + parsedUrl.hash;
-          }
-          return parsedUrl.href;
-        }
-      }
-      return null;
-    };
-
-    const hardenedComponents: Components = {
-      a: ({ href, children, node, ...props }) => {
-        const transformedUrl = transformUrl(href, allowedLinkPrefixes);
-        if (transformedUrl !== null) {
-          // If user provided a custom 'a' component, use it with the transformed URL
-          if (userComponents?.a) {
-            return createElement(userComponents.a, {
-              href: transformedUrl,
-              children,
-              node,
-              target: "_blank",
-              rel: "noopener noreferrer",
-              ...props,
-            });
-          }
-
-          // Otherwise use default anchor with security attributes
-          return (
-            <a
-              href={transformedUrl}
-              {...props}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              {children}
-            </a>
-          );
-        }
-        return (
-          <span className="text-gray-500" title={`Blocked URL: ${href}`}>
-            {children} [blocked]
-          </span>
-        );
-      },
-      img: ({ src, alt, node, ...props }) => {
-        const transformedUrl = transformUrl(src, allowedImagePrefixes);
-        if (transformedUrl !== null) {
-          // If user provided a custom 'img' component, use it with the transformed URL
-          if (userComponents?.img) {
-            return createElement(userComponents.img, {
-              src: transformedUrl,
-              alt,
-              node,
-              ...props,
-            });
-          }
-
-          // Otherwise use default img
-          return <img src={transformedUrl} alt={alt} {...props} />;
-        }
-        return (
-          <span className="inline-block bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-400 px-3 py-1 rounded text-sm">
-            [Image blocked: {alt || "No description"}]
-          </span>
-        );
-      },
-    };
-
-    const mergedComponents = {
-      ...userComponents,
-      ...hardenedComponents,
-    };
-
-    const componentProps = {
-      ...reactMarkdownProps,
-      components: mergedComponents,
-    } as MarkdownComponentProps<TMarkdownComponent>;
-
-    return createElement(MarkdownComponent, componentProps);
+export default function hardenReactMarkdown(
+  MarkdownComponent: ComponentType<Options>,
+): ComponentType<Options & HardenReactMarkdownOptions> {
+  return function HardenedReactMarkdown({
+    defaultOrigin,
+    allowedLinkPrefixes,
+    allowedImagePrefixes,
+    rehypePlugins,
+    ...props
+  }: Options & HardenReactMarkdownOptions) {
+    return (
+      <MarkdownComponent
+        {...props}
+        rehypePlugins={[
+          [
+            harden,
+            { defaultOrigin, allowedLinkPrefixes, allowedImagePrefixes },
+          ],
+          ...(rehypePlugins ?? []),
+        ]}
+      />
+    );
   };
 }

--- a/package.json
+++ b/package.json
@@ -9,5 +9,6 @@
   },
   "keywords": [],
   "author": "",
-  "license": "MIT"
+  "license": "MIT",
+  "packageManager": "pnpm@9.15.9+sha512.68046141893c66fad01c079231128e9afb89ef87e2691d69e4d40eee228988295fd4682181bae55b58418c3a253bde65a505ec7c5f9403ece5cc3cd37dcf2531"
 }

--- a/rehype-harden/LICENSE.md
+++ b/rehype-harden/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Vercel Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/rehype-harden/package.json
+++ b/rehype-harden/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "rehype-harden",
+  "version": "1.0.0",
+  "description": "A security-focused rehype plugin that filters URLs based on allowed prefixes",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest --run",
+    "test:watch": "vitest --watch",
+    "test:ui": "vitest --ui",
+    "prepublishOnly": "pnpm run build && pnpm test"
+  },
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "keywords": [
+    "rehype",
+    "markdown",
+    "security",
+    "url-filtering",
+    "xss-protection"
+  ],
+  "author": "S. Elliott Johnson",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel-labs/markdown-sanitizers.git"
+  },
+  "bugs": {
+    "url": "https://github.com/vercel-labs/markdown-sanitizers/issues"
+  },
+  "homepage": "https://github.com/vercel-labs/markdown-sanitizers#readme",
+  "devDependencies": {
+    "@types/hast": "^3.0.4",
+    "remark-parse": "^11.0.0",
+    "remark-rehype": "^11.1.1",
+    "rehype-stringify": "^10.0.1",
+    "typescript": "^5",
+    "unified": "^11.0.5",
+    "unist-util-visit": "^5.0.0",
+    "vite": "^7.0.6",
+    "vitest": "^3.2.4"
+  }
+}

--- a/rehype-harden/pnpm-lock.yaml
+++ b/rehype-harden/pnpm-lock.yaml
@@ -1,0 +1,1484 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@types/hast':
+        specifier: ^3.0.4
+        version: 3.0.4
+      rehype-stringify:
+        specifier: ^10.0.1
+        version: 10.0.1
+      remark-parse:
+        specifier: ^11.0.0
+        version: 11.0.0
+      remark-rehype:
+        specifier: ^11.1.1
+        version: 11.1.2
+      typescript:
+        specifier: ^5
+        version: 5.9.2
+      unified:
+        specifier: ^11.0.5
+        version: 11.0.5
+      unist-util-visit:
+        specifier: ^5.0.0
+        version: 5.0.0
+      vite:
+        specifier: ^7.0.6
+        version: 7.1.6
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.12)
+
+packages:
+
+  '@esbuild/aix-ppc64@0.25.10':
+    resolution: {integrity: sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.10':
+    resolution: {integrity: sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.10':
+    resolution: {integrity: sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.10':
+    resolution: {integrity: sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.10':
+    resolution: {integrity: sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.10':
+    resolution: {integrity: sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.10':
+    resolution: {integrity: sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.10':
+    resolution: {integrity: sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.10':
+    resolution: {integrity: sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.10':
+    resolution: {integrity: sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.10':
+    resolution: {integrity: sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.10':
+    resolution: {integrity: sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.10':
+    resolution: {integrity: sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.10':
+    resolution: {integrity: sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.10':
+    resolution: {integrity: sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.10':
+    resolution: {integrity: sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.10':
+    resolution: {integrity: sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.10':
+    resolution: {integrity: sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.10':
+    resolution: {integrity: sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.10':
+    resolution: {integrity: sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.10':
+    resolution: {integrity: sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.10':
+    resolution: {integrity: sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.10':
+    resolution: {integrity: sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.10':
+    resolution: {integrity: sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.10':
+    resolution: {integrity: sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.10':
+    resolution: {integrity: sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@rollup/rollup-android-arm-eabi@4.52.0':
+    resolution: {integrity: sha512-VxDYCDqOaR7NXzAtvRx7G1u54d2kEHopb28YH/pKzY6y0qmogP3gG7CSiWsq9WvDFxOQMpNEyjVAHZFXfH3o/A==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.52.0':
+    resolution: {integrity: sha512-pqDirm8koABIKvzL59YI9W9DWbRlTX7RWhN+auR8HXJxo89m4mjqbah7nJZjeKNTNYopqL+yGg+0mhCpf3xZtQ==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.52.0':
+    resolution: {integrity: sha512-YCdWlY/8ltN6H78HnMsRHYlPiKvqKagBP1r+D7SSylxX+HnsgXGCmLiV3Y4nSyY9hW8qr8U9LDUx/Lo7M6MfmQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.52.0':
+    resolution: {integrity: sha512-z4nw6y1j+OOSGzuVbSWdIp1IUks9qNw4dc7z7lWuWDKojY38VMWBlEN7F9jk5UXOkUcp97vA1N213DF+Lz8BRg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.52.0':
+    resolution: {integrity: sha512-Q/dv9Yvyr5rKlK8WQJZVrp5g2SOYeZUs9u/t2f9cQ2E0gJjYB/BWoedXfUT0EcDJefi2zzVfhcOj8drWCzTviw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.52.0':
+    resolution: {integrity: sha512-kdBsLs4Uile/fbjZVvCRcKB4q64R+1mUq0Yd7oU1CMm1Av336ajIFqNFovByipciuUQjBCPMxwJhCgfG2re3rg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.52.0':
+    resolution: {integrity: sha512-aL6hRwu0k7MTUESgkg7QHY6CoqPgr6gdQXRJI1/VbFlUMwsSzPGSR7sG5d+MCbYnJmJwThc2ol3nixj1fvI/zQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.52.0':
+    resolution: {integrity: sha512-BTs0M5s1EJejgIBJhCeiFo7GZZ2IXWkFGcyZhxX4+8usnIo5Mti57108vjXFIQmmJaRyDwmV59Tw64Ap1dkwMw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.52.0':
+    resolution: {integrity: sha512-uj672IVOU9m08DBGvoPKPi/J8jlVgjh12C9GmjjBxCTQc3XtVmRkRKyeHSmIKQpvJ7fIm1EJieBUcnGSzDVFyw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.52.0':
+    resolution: {integrity: sha512-/+IVbeDMDCtB/HP/wiWsSzduD10SEGzIZX2945KSgZRNi4TSkjHqRJtNTVtVb8IRwhJ65ssI56krlLik+zFWkw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.52.0':
+    resolution: {integrity: sha512-U1vVzvSWtSMWKKrGoROPBXMh3Vwn93TA9V35PldokHGqiUbF6erSzox/5qrSMKp6SzakvyjcPiVF8yB1xKr9Pg==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.52.0':
+    resolution: {integrity: sha512-X/4WfuBAdQRH8cK3DYl8zC00XEE6aM472W+QCycpQJeLWVnHfkv7RyBFVaTqNUMsTgIX8ihMjCvFF9OUgeABzw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.52.0':
+    resolution: {integrity: sha512-xIRYc58HfWDBZoLmWfWXg2Sq8VCa2iJ32B7mqfWnkx5mekekl0tMe7FHpY8I72RXEcUkaWawRvl3qA55og+cwQ==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.52.0':
+    resolution: {integrity: sha512-mbsoUey05WJIOz8U1WzNdf+6UMYGwE3fZZnQqsM22FZ3wh1N887HT6jAOjXs6CNEK3Ntu2OBsyQDXfIjouI4dw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.52.0':
+    resolution: {integrity: sha512-qP6aP970bucEi5KKKR4AuPFd8aTx9EF6BvutvYxmZuWLJHmnq4LvBfp0U+yFDMGwJ+AIJEH5sIP+SNypauMWzg==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.52.0':
+    resolution: {integrity: sha512-nmSVN+F2i1yKZ7rJNKO3G7ZzmxJgoQBQZ/6c4MuS553Grmr7WqR7LLDcYG53Z2m9409z3JLt4sCOhLdbKQ3HmA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.52.0':
+    resolution: {integrity: sha512-2d0qRo33G6TfQVjaMR71P+yJVGODrt5V6+T0BDYH4EMfGgdC/2HWDVjSSFw888GSzAZUwuska3+zxNUCDco6rQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openharmony-arm64@4.52.0':
+    resolution: {integrity: sha512-A1JalX4MOaFAAyGgpO7XP5khquv/7xKzLIyLmhNrbiCxWpMlnsTYr8dnsWM7sEeotNmxvSOEL7F65j0HXFcFsw==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.52.0':
+    resolution: {integrity: sha512-YQugafP/rH0eOOHGjmNgDURrpYHrIX0yuojOI8bwCyXwxC9ZdTd3vYkmddPX0oHONLXu9Rb1dDmT0VNpjkzGGw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.52.0':
+    resolution: {integrity: sha512-zYdUYhi3Qe2fndujBqL5FjAFzvNeLxtIqfzNEVKD1I7C37/chv1VxhscWSQHTNfjPCrBFQMnynwA3kpZpZ8w4A==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.52.0':
+    resolution: {integrity: sha512-fGk03kQylNaCOQ96HDMeT7E2n91EqvCDd3RwvT5k+xNdFCeMGnj5b5hEgTGrQuyidqSsD3zJDQ21QIaxXqTBJw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.52.0':
+    resolution: {integrity: sha512-6iKDCVSIUQ8jPMoIV0OytRKniaYyy5EbY/RRydmLW8ZR3cEBhxbWl5ro0rkUNe0ef6sScvhbY79HrjRm8i3vDQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/chai@5.2.2':
+    resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
+
+  '@types/debug@4.1.12':
+    resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@ungap/structured-clone@1.3.0':
+    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  check-error@2.1.1:
+    resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
+    engines: {node: '>= 16'}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  decode-named-character-reference@1.2.0:
+    resolution: {integrity: sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==}
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.25.10:
+    resolution: {integrity: sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.2.2:
+    resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
+    engines: {node: '>=12.0.0'}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  hast-util-to-html@9.0.5:
+    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  magic-string@0.30.19:
+    resolution: {integrity: sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==}
+
+  mdast-util-from-markdown@2.0.2:
+    resolution: {integrity: sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==}
+
+  mdast-util-to-hast@13.2.0:
+    resolution: {integrity: sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.6:
+    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  property-information@7.1.0:
+    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
+  rehype-stringify@10.0.1:
+    resolution: {integrity: sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  rollup@4.52.0:
+    resolution: {integrity: sha512-+IuescNkTJQgX7AkIDtITipZdIGcWF0pnVvZTWStiazUmcGA2ag8dfg0urest2XlXUi9kuhfQ+qmdc5Stc3z7g==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.9.0:
+    resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
+
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
+  strip-literal@3.0.0:
+    resolution: {integrity: sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
+
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
+  typescript@5.9.2:
+    resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-is@6.0.0:
+    resolution: {integrity: sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.1:
+    resolution: {integrity: sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==}
+
+  unist-util-visit@5.0.0:
+    resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@7.1.6:
+    resolution: {integrity: sha512-SRYIB8t/isTwNn8vMB3MR6E+EQZM/WG1aKmmIUCfDXfVvKfc20ZpamngWHKzAmmu9ppsgxsg4b2I7c90JZudIQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.25.10':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/android-arm@0.25.10':
+    optional: true
+
+  '@esbuild/android-x64@0.25.10':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.10':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.10':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.10':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.10':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.10':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.10':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.10':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.10':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.10':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.10':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.10':
+    optional: true
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@rollup/rollup-android-arm-eabi@4.52.0':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.52.0':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.52.0':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.52.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.52.0':
+    optional: true
+
+  '@types/chai@5.2.2':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+
+  '@types/debug@4.1.12':
+    dependencies:
+      '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.8': {}
+
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/ms@2.1.0': {}
+
+  '@types/unist@3.0.3': {}
+
+  '@ungap/structured-clone@1.3.0': {}
+
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.2
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@7.1.6)':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.19
+    optionalDependencies:
+      vite: 7.1.6
+
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.0.0
+
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.19
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
+  assertion-error@2.0.1: {}
+
+  bail@2.0.2: {}
+
+  cac@6.7.14: {}
+
+  ccount@2.0.1: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.1
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
+
+  check-error@2.1.1: {}
+
+  comma-separated-tokens@2.0.3: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  decode-named-character-reference@1.2.0:
+    dependencies:
+      character-entities: 2.0.2
+
+  deep-eql@5.0.2: {}
+
+  dequal@2.0.3: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
+
+  es-module-lexer@1.7.0: {}
+
+  esbuild@0.25.10:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.10
+      '@esbuild/android-arm': 0.25.10
+      '@esbuild/android-arm64': 0.25.10
+      '@esbuild/android-x64': 0.25.10
+      '@esbuild/darwin-arm64': 0.25.10
+      '@esbuild/darwin-x64': 0.25.10
+      '@esbuild/freebsd-arm64': 0.25.10
+      '@esbuild/freebsd-x64': 0.25.10
+      '@esbuild/linux-arm': 0.25.10
+      '@esbuild/linux-arm64': 0.25.10
+      '@esbuild/linux-ia32': 0.25.10
+      '@esbuild/linux-loong64': 0.25.10
+      '@esbuild/linux-mips64el': 0.25.10
+      '@esbuild/linux-ppc64': 0.25.10
+      '@esbuild/linux-riscv64': 0.25.10
+      '@esbuild/linux-s390x': 0.25.10
+      '@esbuild/linux-x64': 0.25.10
+      '@esbuild/netbsd-arm64': 0.25.10
+      '@esbuild/netbsd-x64': 0.25.10
+      '@esbuild/openbsd-arm64': 0.25.10
+      '@esbuild/openbsd-x64': 0.25.10
+      '@esbuild/openharmony-arm64': 0.25.10
+      '@esbuild/sunos-x64': 0.25.10
+      '@esbuild/win32-arm64': 0.25.10
+      '@esbuild/win32-ia32': 0.25.10
+      '@esbuild/win32-x64': 0.25.10
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  expect-type@1.2.2: {}
+
+  extend@3.0.2: {}
+
+  fdir@6.5.0(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
+
+  fsevents@2.3.3:
+    optional: true
+
+  hast-util-to-html@9.0.5:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 3.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.0
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.4
+      zwitch: 2.0.4
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  html-void-elements@3.0.0: {}
+
+  is-plain-obj@4.1.0: {}
+
+  js-tokens@9.0.1: {}
+
+  loupe@3.2.1: {}
+
+  magic-string@0.30.19:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  mdast-util-from-markdown@2.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.2.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-to-hast@13.2.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.0
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.0.0
+      vfile: 6.0.3
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.2.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.2.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.12
+      debug: 4.4.3
+      decode-named-character-reference: 1.2.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.11: {}
+
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.3: {}
+
+  postcss@8.5.6:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  property-information@7.1.0: {}
+
+  rehype-stringify@10.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+      unified: 11.0.5
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.2
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.0
+      unified: 11.0.5
+      vfile: 6.0.3
+
+  rollup@4.52.0:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.52.0
+      '@rollup/rollup-android-arm64': 4.52.0
+      '@rollup/rollup-darwin-arm64': 4.52.0
+      '@rollup/rollup-darwin-x64': 4.52.0
+      '@rollup/rollup-freebsd-arm64': 4.52.0
+      '@rollup/rollup-freebsd-x64': 4.52.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.52.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.52.0
+      '@rollup/rollup-linux-arm64-gnu': 4.52.0
+      '@rollup/rollup-linux-arm64-musl': 4.52.0
+      '@rollup/rollup-linux-loong64-gnu': 4.52.0
+      '@rollup/rollup-linux-ppc64-gnu': 4.52.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.52.0
+      '@rollup/rollup-linux-riscv64-musl': 4.52.0
+      '@rollup/rollup-linux-s390x-gnu': 4.52.0
+      '@rollup/rollup-linux-x64-gnu': 4.52.0
+      '@rollup/rollup-linux-x64-musl': 4.52.0
+      '@rollup/rollup-openharmony-arm64': 4.52.0
+      '@rollup/rollup-win32-arm64-msvc': 4.52.0
+      '@rollup/rollup-win32-ia32-msvc': 4.52.0
+      '@rollup/rollup-win32-x64-gnu': 4.52.0
+      '@rollup/rollup-win32-x64-msvc': 4.52.0
+      fsevents: 2.3.3
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  space-separated-tokens@2.0.2: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.9.0: {}
+
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+
+  strip-literal@3.0.0:
+    dependencies:
+      js-tokens: 9.0.1
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
+
+  trim-lines@3.0.1: {}
+
+  trough@2.2.0: {}
+
+  typescript@5.9.2: {}
+
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
+  unist-util-is@6.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.0
+
+  unist-util-visit@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.0
+      unist-util-visit-parents: 6.0.1
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
+
+  vite-node@3.2.4:
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.1.6
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.1.6:
+    dependencies:
+      esbuild: 0.25.10
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.52.0
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  vitest@3.2.4(@types/debug@4.1.12):
+    dependencies:
+      '@types/chai': 5.2.2
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.1.6)
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.2.2
+      magic-string: 0.30.19
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.1.6
+      vite-node: 3.2.4
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.12
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  zwitch@2.0.4: {}

--- a/rehype-harden/src/index.ts
+++ b/rehype-harden/src/index.ts
@@ -1,0 +1,216 @@
+import type { Nodes as HastNodes, Root as HastRoot } from "hast";
+import { CONTINUE, SKIP, visit, type BuildVisitor } from "unist-util-visit";
+
+export function harden({
+  defaultOrigin = "",
+  allowedLinkPrefixes = [],
+  allowedImagePrefixes = [],
+  blockedImageClass = "inline-block bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-400 px-3 py-1 rounded text-sm",
+  blockedLinkClass = "text-gray-500",
+}: {
+  defaultOrigin?: string;
+  allowedLinkPrefixes?: string[];
+  allowedImagePrefixes?: string[];
+  blockedImageClass?: string;
+  blockedLinkClass?: string;
+}) {
+  // Only require defaultOrigin if we have specific prefixes (not wildcard only)
+  const hasSpecificLinkPrefixes =
+    allowedLinkPrefixes.length && !allowedLinkPrefixes.every((p) => p === "*");
+  const hasSpecificImagePrefixes =
+    allowedImagePrefixes.length &&
+    !allowedImagePrefixes.every((p) => p === "*");
+
+  if (!defaultOrigin && (hasSpecificLinkPrefixes || hasSpecificImagePrefixes)) {
+    throw new Error(
+      "defaultOrigin is required when allowedLinkPrefixes or allowedImagePrefixes are provided",
+    );
+  }
+
+  return (tree: HastRoot) => {
+    const visitor = createVisitor(
+      defaultOrigin,
+      allowedLinkPrefixes,
+      allowedImagePrefixes,
+      blockedImageClass,
+      blockedLinkClass,
+    );
+    visit(tree, visitor);
+  };
+}
+
+function parseUrl(url: unknown, defaultOrigin: string): URL | null {
+  if (typeof url !== "string") return null;
+  try {
+    // Try to parse as absolute URL first
+    return new URL(url);
+  } catch {
+    // If that fails and we have a defaultOrigin, try with it
+    if (defaultOrigin) {
+      try {
+        return new URL(url, defaultOrigin);
+      } catch {
+        return null;
+      }
+    }
+    return null;
+  }
+}
+
+function isPathRelativeUrl(url: unknown): boolean {
+  if (typeof url !== "string") return false;
+  return url.startsWith("/");
+}
+
+const safeProtocols = new Set([
+  "https:",
+  "http:",
+  "irc:",
+  "ircs:",
+  "mailto:",
+  "xmpp:",
+]);
+
+function transformUrl(
+  url: unknown,
+  allowedPrefixes: string[],
+  defaultOrigin: string,
+): string | null {
+  if (!url) return null;
+  const parsedUrl = parseUrl(url, defaultOrigin);
+  if (!parsedUrl) return null;
+  if (!safeProtocols.has(parsedUrl.protocol)) return null;
+
+  // If the input is path relative, we output a path relative URL as well,
+  // however, we always run the same checks on an absolute URL and we
+  // always rescronstruct the output from the parsed URL to ensure that
+  // the output is always a valid URL.
+  const inputWasRelative = isPathRelativeUrl(url);
+  const urlString = parseUrl(url, defaultOrigin);
+  if (
+    urlString &&
+    allowedPrefixes.some((prefix) => {
+      const parsedPrefix = parseUrl(prefix, defaultOrigin);
+      if (!parsedPrefix) {
+        return false;
+      }
+      if (parsedPrefix.origin !== urlString.origin) {
+        return false;
+      }
+      return urlString.href.startsWith(parsedPrefix.href);
+    })
+  ) {
+    if (inputWasRelative) {
+      return urlString.pathname + urlString.search + urlString.hash;
+    }
+    return urlString.href;
+  }
+
+  // Check for wildcard - allow all URLs
+  if (allowedPrefixes.includes("*")) {
+    // Wildcard only allows http and https URLs
+    if (parsedUrl.protocol !== "https:" && parsedUrl.protocol !== "http:") {
+      return null;
+    }
+    if (inputWasRelative) {
+      return parsedUrl.pathname + parsedUrl.search + parsedUrl.hash;
+    }
+    return parsedUrl.href;
+  }
+  return null;
+}
+
+const SEEN = Symbol("node-seen");
+
+const createVisitor = (
+  defaultOrigin: string,
+  allowedLinkPrefixes: string[],
+  allowedImagePrefixes: string[],
+  blockedImageClass: string,
+  blockedLinkClass: string,
+): BuildVisitor<HastNodes> => {
+  const visitor: BuildVisitor<HastNodes> = (node, index, parent) => {
+    if (
+      node.type !== "element" ||
+      // @ts-expect-error
+      node[SEEN]
+    ) {
+      return CONTINUE;
+    }
+
+    if (node.tagName === "a") {
+      const transformedUrl = transformUrl(
+        node.properties.href,
+        allowedLinkPrefixes,
+        defaultOrigin,
+      );
+      if (transformedUrl === null) {
+        // @ts-expect-error
+        node[SEEN] = true;
+        visit(node, visitor);
+        if (parent && typeof index === "number") {
+          parent.children[index] = {
+            type: "element",
+            tagName: "span",
+            properties: {
+              title: "Blocked URL: " + String(node.properties.href),
+              class: blockedLinkClass,
+            },
+            children: [
+              ...node.children,
+              {
+                type: "text",
+                value: " [blocked]",
+              },
+            ],
+          };
+        }
+        return SKIP;
+      } else {
+        node.properties.href = transformedUrl;
+        node.properties.target = "_blank";
+        node.properties.rel = "noopener noreferrer";
+        return CONTINUE;
+      }
+    }
+
+    if (node.tagName === "img") {
+      const transformedUrl = transformUrl(
+        node.properties.src,
+        allowedImagePrefixes,
+        defaultOrigin,
+      );
+      if (transformedUrl === null) {
+        // @ts-expect-error
+        node[SEEN] = true;
+        visit(node, visitor);
+        if (parent && typeof index === "number") {
+          parent.children[index] = {
+            type: "element",
+            tagName: "span",
+            properties: {
+              class: blockedImageClass,
+            },
+            children: [
+              {
+                type: "text",
+                value:
+                  "[Image blocked: " +
+                  String(node.properties.alt || "No description") +
+                  "]",
+              },
+            ],
+          };
+        }
+        return SKIP;
+      } else {
+        node.properties.src = transformedUrl;
+        return CONTINUE;
+      }
+    }
+
+    return CONTINUE;
+  };
+
+  return visitor;
+};

--- a/rehype-harden/src/tests/index.test.ts
+++ b/rehype-harden/src/tests/index.test.ts
@@ -1,0 +1,1052 @@
+import { describe, it, expect } from "vitest";
+import { unified } from "unified";
+import remarkParse from "remark-parse";
+import remarkRehype from "remark-rehype";
+import rehypeStringify from "rehype-stringify";
+import type { Root as HastRoot, Element, Text } from "hast";
+import { harden } from "../index.js";
+
+// Helper function to process markdown through our plugin
+async function processMarkdown(
+  markdown: string,
+  options: Parameters<typeof harden>[0] = {},
+): Promise<HastRoot> {
+  let tree: HastRoot | undefined;
+
+  const processor = unified()
+    .use(remarkParse)
+    .use(remarkRehype)
+    .use(harden, options)
+    .use(() => (hastTree) => {
+      tree = hastTree as HastRoot;
+    })
+    .use(rehypeStringify);
+
+  await processor.process(markdown);
+
+  if (!tree) {
+    throw new Error("Failed to capture HAST tree");
+  }
+
+  return tree;
+}
+
+// Helper function to find elements by tag name (recursive)
+function findElement(tree: HastRoot, tagName: string): Element | null {
+  function search(node: any): Element | null {
+    if (node.type === "element" && node.tagName === tagName) {
+      return node;
+    }
+    if (node.children) {
+      for (const child of node.children) {
+        const result = search(child);
+        if (result) return result;
+      }
+    }
+    return null;
+  }
+
+  return search(tree);
+}
+
+// Helper function to find elements by tag name (all matches, recursive)
+function findElements(tree: HastRoot, tagName: string): Element[] {
+  const elements: Element[] = [];
+
+  function search(node: any): void {
+    if (node.type === "element" && node.tagName === tagName) {
+      elements.push(node);
+    }
+    if (node.children) {
+      for (const child of node.children) {
+        search(child);
+      }
+    }
+  }
+
+  search(tree);
+  return elements;
+}
+
+// Helper function to find text content
+function getTextContent(element: Element): string {
+  let text = "";
+  for (const child of element.children) {
+    if (child.type === "text") {
+      text += child.value;
+    } else if (child.type === "element") {
+      text += getTextContent(child);
+    }
+  }
+  return text;
+}
+
+// Helper function to find span elements with specific text content (recursive)
+function findSpanWithText(tree: HastRoot, text: string): Element | null {
+  function search(node: any): Element | null {
+    if (node.type === "element" && node.tagName === "span") {
+      const spanText = getTextContent(node);
+      if (spanText.includes(text)) {
+        return node;
+      }
+    }
+    if (node.children) {
+      for (const child of node.children) {
+        const result = search(child);
+        if (result) return result;
+      }
+    }
+    return null;
+  }
+
+  return search(tree);
+}
+
+describe("rehype-harden", () => {
+  // Helper function to test blocked URLs concisely
+  const testBlockedUrls = (
+    urlType: "link" | "image",
+    badUrls: string[],
+    allowedPrefixes: string[],
+    defaultOrigin: string,
+  ) => {
+    it.each(badUrls)(`blocks ${urlType} with URL: %s`, async (url) => {
+      const markdown =
+        urlType === "link" ? `[Test](${url})` : `![Test](${url})`;
+
+      const tree = await processMarkdown(markdown, {
+        defaultOrigin,
+        allowedLinkPrefixes: urlType === "link" ? allowedPrefixes : [],
+        allowedImagePrefixes: urlType === "image" ? allowedPrefixes : [],
+      });
+
+      if (urlType === "link") {
+        // Should not have any <a> elements
+        const link = findElement(tree, "a");
+        expect(link).toBeNull();
+
+        // Should have a span with [blocked] text
+        const blockedSpan = findSpanWithText(tree, "[blocked]");
+        expect(blockedSpan).not.toBeNull();
+        expect(getTextContent(blockedSpan!)).toContain("Test [blocked]");
+      } else {
+        // Should not have any <img> elements
+        const img = findElement(tree, "img");
+        expect(img).toBeNull();
+
+        // Should have a span with blocked image text
+        const blockedSpan = findSpanWithText(tree, "[Image blocked:");
+        expect(blockedSpan).not.toBeNull();
+        expect(getTextContent(blockedSpan!)).toContain("[Image blocked: Test]");
+      }
+    });
+  };
+
+  describe("defaultOrigin requirement", () => {
+    it("throws error when allowedLinkPrefixes provided without defaultOrigin", async () => {
+      await expect(
+        processMarkdown("[Test](https://github.com)", {
+          allowedLinkPrefixes: ["https://github.com/"],
+        }),
+      ).rejects.toThrow(
+        "defaultOrigin is required when allowedLinkPrefixes or allowedImagePrefixes are provided",
+      );
+    });
+
+    it("throws error when allowedImagePrefixes provided without defaultOrigin", async () => {
+      await expect(
+        processMarkdown("![Test](https://example.com/image.jpg)", {
+          allowedImagePrefixes: ["https://example.com/"],
+        }),
+      ).rejects.toThrow(
+        "defaultOrigin is required when allowedLinkPrefixes or allowedImagePrefixes are provided",
+      );
+    });
+
+    it("does not throw when no prefixes are provided", async () => {
+      await expect(
+        processMarkdown("[Test](https://github.com)"),
+      ).resolves.not.toThrow();
+    });
+  });
+
+  describe("URL transformation", () => {
+    it("preserves relative URLs when input is relative and allowed", async () => {
+      const tree = await processMarkdown("[Test](/path/to/page?query=1#hash)", {
+        defaultOrigin: "https://example.com",
+        allowedLinkPrefixes: ["https://example.com/"],
+      });
+
+      const link = findElement(tree, "a");
+      expect(link).not.toBeNull();
+      expect(link!.properties.href).toBe("/path/to/page?query=1#hash");
+    });
+
+    it("returns absolute URL when input is absolute and allowed", async () => {
+      const tree = await processMarkdown(
+        "[Test](https://github.com/user/repo)",
+        {
+          defaultOrigin: "https://example.com",
+          allowedLinkPrefixes: ["https://github.com/"],
+        },
+      );
+
+      const link = findElement(tree, "a");
+      expect(link).not.toBeNull();
+      expect(link!.properties.href).toBe("https://github.com/user/repo");
+    });
+
+    it("correctly resolves relative URLs against defaultOrigin for validation", async () => {
+      const tree = await processMarkdown("[Test](/api/data)", {
+        defaultOrigin: "https://trusted.com",
+        allowedLinkPrefixes: ["https://trusted.com/"],
+      });
+
+      const link = findElement(tree, "a");
+      expect(link).not.toBeNull();
+      expect(link!.properties.href).toBe("/api/data");
+    });
+
+    it("blocks relative URLs that resolve to disallowed origins", async () => {
+      const tree = await processMarkdown("[Test](/api/data)", {
+        defaultOrigin: "https://untrusted.com",
+        allowedLinkPrefixes: ["https://trusted.com/"],
+      });
+
+      const link = findElement(tree, "a");
+      expect(link).toBeNull();
+
+      const blockedSpan = findSpanWithText(tree, "[blocked]");
+      expect(blockedSpan).not.toBeNull();
+    });
+
+    it("handles protocol-relative URLs", async () => {
+      const tree = await processMarkdown("[Test](//cdn.example.com/resource)", {
+        defaultOrigin: "https://example.com",
+        allowedLinkPrefixes: ["https://cdn.example.com/"],
+      });
+
+      const link = findElement(tree, "a");
+      expect(link).not.toBeNull();
+      expect(link!.properties.href).toBe("/resource");
+    });
+
+    it("normalizes URLs to prevent bypasses", async () => {
+      const tree = await processMarkdown(
+        "[Test](https://github.com/../../../evil.com)",
+        {
+          defaultOrigin: "https://example.com",
+          allowedLinkPrefixes: ["https://github.com/"],
+        },
+      );
+
+      const link = findElement(tree, "a");
+      expect(link).not.toBeNull();
+      expect(link!.properties.href).toBe("https://github.com/evil.com");
+    });
+  });
+
+  describe("Bad URL cases - Links", () => {
+    const badLinkUrls = [
+      'javascript:alert("XSS")',
+      'data:text/html,<script>alert("XSS")</script>',
+      'vbscript:msgbox("XSS")',
+      "file:///etc/passwd",
+      "about:blank",
+      "blob:https://example.com/uuid",
+      "mailto:user@example.com",
+      "tel:+1234567890",
+      "ftp://ftp.example.com/file",
+      "../../../etc/passwd",
+      "//evil.com/malware",
+      "https://evil.com@github.com",
+      "https://github.com.evil.com",
+      "https://github.com%2e%2e%2f%2e%2e%2fevil.com",
+      "https://github.com\\.evil.com",
+      "https://github.com%00.evil.com",
+      "https://github.com%E2%80%8B.evil.com", // Zero-width space
+      "\x00javascript:alert(1)",
+      " javascript:alert(1)",
+      "javascript\x00:alert(1)",
+      "jav&#x61;script:alert(1)",
+      "jav&#97;script:alert(1)",
+    ];
+
+    testBlockedUrls(
+      "link",
+      badLinkUrls,
+      ["https://github.com/"],
+      "https://example.com",
+    );
+
+    testBlockedUrls(
+      "link",
+      badLinkUrls,
+      ["https://github.com"],
+      "https://example.com",
+    );
+  });
+
+  describe("Bad URL cases - Images", () => {
+    const badImageUrls = [
+      "javascript:void(0)",
+      "vbscript:execute",
+      "file:///etc/passwd",
+      "blob:https://example.com/uuid",
+      "../../../sensitive.jpg",
+      "//evil.com/tracker.gif",
+      "https://evil.com@trusted.com/image.jpg",
+      "https://trusted.com.evil.com/image.jpg",
+      "\x00javascript:void(0)",
+    ];
+
+    testBlockedUrls(
+      "image",
+      badImageUrls,
+      ["https://trusted.com/"],
+      "https://example.com",
+    );
+  });
+
+  describe("Edge cases with malformed URLs", () => {
+    it("handles null href gracefully", async () => {
+      const tree = await processMarkdown("[Test]()", {
+        defaultOrigin: "https://example.com",
+      });
+
+      const blockedSpan = findSpanWithText(tree, "[blocked]");
+      expect(blockedSpan).not.toBeNull();
+    });
+
+    it("handles undefined src gracefully", async () => {
+      const tree = await processMarkdown("![Test]()", {
+        defaultOrigin: "https://example.com",
+      });
+
+      const blockedSpan = findSpanWithText(tree, "[Image blocked:");
+      expect(blockedSpan).not.toBeNull();
+    });
+
+    it("handles numeric URL inputs", async () => {
+      const tree = await processMarkdown("[Test](123)", {
+        defaultOrigin: "https://example.com",
+        allowedLinkPrefixes: ["https://example.com/"],
+      });
+
+      const link = findElement(tree, "a");
+      expect(link).not.toBeNull();
+      expect(link!.properties.href).toBe("https://example.com/123");
+    });
+
+    it("handles URLs with unicode characters", async () => {
+      const tree = await processMarkdown(
+        "[Test](https://example.com/路径/文件)",
+        {
+          defaultOrigin: "https://example.com",
+          allowedLinkPrefixes: ["https://example.com/"],
+        },
+      );
+
+      const link = findElement(tree, "a");
+      expect(link).not.toBeNull();
+      expect(link!.properties.href).toBe(
+        "https://example.com/%E8%B7%AF%E5%BE%84/%E6%96%87%E4%BB%B6",
+      );
+    });
+
+    it("handles extremely long URLs", async () => {
+      const longPath = "a".repeat(10000);
+      const tree = await processMarkdown(
+        `[Test](https://example.com/${longPath})`,
+        {
+          defaultOrigin: "https://example.com",
+          allowedLinkPrefixes: ["https://example.com/"],
+        },
+      );
+
+      const link = findElement(tree, "a");
+      expect(link).not.toBeNull();
+      expect(link!.properties.href).toBe(`https://example.com/${longPath}`);
+    });
+  });
+
+  describe("Basic markdown rendering", () => {
+    it("renders headings correctly", async () => {
+      const tree = await processMarkdown("# Heading 1\n## Heading 2");
+
+      const h1 = findElement(tree, "h1");
+      const h2 = findElement(tree, "h2");
+
+      expect(h1).not.toBeNull();
+      expect(h2).not.toBeNull();
+      expect(getTextContent(h1!)).toBe("Heading 1");
+      expect(getTextContent(h2!)).toBe("Heading 2");
+    });
+
+    it("renders paragraphs and text formatting", async () => {
+      const tree = await processMarkdown(
+        "This is **bold** and this is *italic*",
+      );
+
+      const p = findElement(tree, "p");
+      expect(p).not.toBeNull();
+
+      const strong = p!.children.find(
+        (child) => child.type === "element" && child.tagName === "strong",
+      ) as Element;
+      const em = p!.children.find(
+        (child) => child.type === "element" && child.tagName === "em",
+      ) as Element;
+
+      expect(strong).not.toBeNull();
+      expect(em).not.toBeNull();
+      expect(getTextContent(strong)).toBe("bold");
+      expect(getTextContent(em)).toBe("italic");
+    });
+
+    it("renders lists correctly", async () => {
+      const markdown = `
+- Item 1
+- Item 2
+
+1. First
+2. Second
+      `;
+
+      const tree = await processMarkdown(markdown);
+
+      const ul = findElement(tree, "ul");
+      const ol = findElement(tree, "ol");
+
+      expect(ul).not.toBeNull();
+      expect(ol).not.toBeNull();
+    });
+
+    it("renders code blocks", async () => {
+      const tree = await processMarkdown(`\`inline code\`
+
+\`\`\`
+block code
+\`\`\``);
+
+      const p = findElement(tree, "p");
+      const pre = findElement(tree, "pre");
+
+      expect(p).not.toBeNull();
+      expect(pre).not.toBeNull();
+
+      const code = p!.children.find(
+        (child) => child.type === "element" && child.tagName === "code",
+      ) as Element;
+      expect(code).not.toBeNull();
+      expect(getTextContent(code)).toBe("inline code");
+    });
+  });
+
+  describe("Security properties - Links", () => {
+    it("blocks all links when no prefixes are allowed", async () => {
+      const tree = await processMarkdown("[GitHub](https://github.com)");
+
+      const link = findElement(tree, "a");
+      expect(link).toBeNull();
+
+      const blockedSpan = findSpanWithText(tree, "[blocked]");
+      expect(blockedSpan).not.toBeNull();
+    });
+
+    it("blocks all links when empty allowedLinkPrefixes array is provided", async () => {
+      const tree = await processMarkdown("[GitHub](https://github.com)", {
+        defaultOrigin: "https://example.com",
+        allowedLinkPrefixes: [],
+      });
+
+      const link = findElement(tree, "a");
+      expect(link).toBeNull();
+
+      const blockedSpan = findSpanWithText(tree, "[blocked]");
+      expect(blockedSpan).not.toBeNull();
+    });
+
+    it("allows links with allowed prefixes", async () => {
+      const tree = await processMarkdown(
+        "[GitHub](https://github.com/user/repo)",
+        {
+          defaultOrigin: "https://example.com",
+          allowedLinkPrefixes: ["https://github.com/"],
+        },
+      );
+
+      const link = findElement(tree, "a");
+      expect(link).not.toBeNull();
+      expect(link!.properties.href).toBe("https://github.com/user/repo");
+      expect(link!.properties.target).toBe("_blank");
+      expect(link!.properties.rel).toBe("noopener noreferrer");
+    });
+
+    it("blocks links that do not match allowed prefixes", async () => {
+      const tree = await processMarkdown(
+        `
+[Allowed](https://github.com/repo)
+[Blocked](https://evil.com/malware)
+      `,
+        {
+          defaultOrigin: "https://example.com",
+          allowedLinkPrefixes: ["https://github.com/"],
+        },
+      );
+
+      const links = findElements(tree, "a");
+      expect(links).toHaveLength(1);
+      expect(getTextContent(links[0])).toBe("Allowed");
+
+      const blockedSpan = findSpanWithText(tree, "[blocked]");
+      expect(blockedSpan).not.toBeNull();
+    });
+
+    it("handles multiple allowed prefixes", async () => {
+      const tree = await processMarkdown(
+        `
+[GitHub](https://github.com/repo)
+[Docs](https://docs.example.com/page)
+[Website](https://www.example.com/)
+[Blocked](https://malicious.com)
+      `,
+        {
+          defaultOrigin: "https://example.com",
+          allowedLinkPrefixes: [
+            "https://github.com/",
+            "https://docs.example.com",
+            "https://www.example.com",
+          ],
+        },
+      );
+
+      const links = findElements(tree, "a");
+      expect(links).toHaveLength(3);
+
+      const hrefs = links.map((link) => link.properties.href);
+      expect(hrefs).toContain("https://github.com/repo");
+      expect(hrefs).toContain("https://docs.example.com/page");
+      expect(hrefs).toContain("https://www.example.com/");
+
+      const blockedSpan = findSpanWithText(tree, "[blocked]");
+      expect(blockedSpan).not.toBeNull();
+    });
+  });
+
+  describe("Security properties - Images", () => {
+    it("blocks all images when no prefixes are allowed", async () => {
+      const tree = await processMarkdown(
+        "![Alt text](https://example.com/image.jpg)",
+      );
+
+      const img = findElement(tree, "img");
+      expect(img).toBeNull();
+
+      const blockedSpan = findSpanWithText(tree, "[Image blocked:");
+      expect(blockedSpan).not.toBeNull();
+    });
+
+    it("blocks all images when empty allowedImagePrefixes array is provided", async () => {
+      const tree = await processMarkdown(
+        "![Alt text](https://example.com/image.jpg)",
+        {
+          defaultOrigin: "https://example.com",
+          allowedImagePrefixes: [],
+        },
+      );
+
+      const img = findElement(tree, "img");
+      expect(img).toBeNull();
+
+      const blockedSpan = findSpanWithText(tree, "[Image blocked:");
+      expect(blockedSpan).not.toBeNull();
+    });
+
+    it("allows images with allowed prefixes", async () => {
+      const tree = await processMarkdown(
+        "![Placeholder](https://via.placeholder.com/150)",
+        {
+          defaultOrigin: "https://example.com",
+          allowedImagePrefixes: ["https://via.placeholder.com/"],
+        },
+      );
+
+      const img = findElement(tree, "img");
+      expect(img).not.toBeNull();
+      expect(img!.properties.src).toBe("https://via.placeholder.com/150");
+      expect(img!.properties.alt).toBe("Placeholder");
+    });
+
+    it("blocks images that do not match allowed prefixes", async () => {
+      const tree = await processMarkdown(
+        `
+![Allowed](https://via.placeholder.com/150)
+![Blocked](https://evil.com/malware.jpg)
+      `,
+        {
+          defaultOrigin: "https://example.com",
+          allowedImagePrefixes: ["https://via.placeholder.com/"],
+        },
+      );
+
+      const imgs = findElements(tree, "img");
+      expect(imgs).toHaveLength(1);
+      expect(imgs[0].properties.alt).toBe("Allowed");
+
+      const blockedSpan = findSpanWithText(tree, "[Image blocked:");
+      expect(blockedSpan).not.toBeNull();
+    });
+
+    it("handles images without alt text", async () => {
+      const tree = await processMarkdown("![](https://example.com/image.jpg)");
+
+      const blockedSpan = findSpanWithText(
+        tree,
+        "[Image blocked: No description]",
+      );
+      expect(blockedSpan).not.toBeNull();
+    });
+
+    it("allows local images with correct origin", async () => {
+      const tree = await processMarkdown("![Logo](/logo.png)", {
+        defaultOrigin: "https://example.com",
+        allowedImagePrefixes: ["https://example.com/"],
+      });
+
+      const img = findElement(tree, "img");
+      expect(img).not.toBeNull();
+      expect(img!.properties.src).toBe("/logo.png");
+    });
+
+    it("transforms relative image URLs correctly", async () => {
+      const tree = await processMarkdown(
+        "![Image](/images/test.jpg?v=1#section)",
+        {
+          defaultOrigin: "https://trusted.com",
+          allowedImagePrefixes: ["https://trusted.com/"],
+        },
+      );
+
+      const img = findElement(tree, "img");
+      expect(img).not.toBeNull();
+      expect(img!.properties.src).toBe("/images/test.jpg?v=1#section");
+    });
+  });
+
+  describe("Edge cases", () => {
+    it("handles undefined href in links", async () => {
+      const tree = await processMarkdown("[No href]()");
+
+      const blockedSpan = findSpanWithText(tree, "[blocked]");
+      expect(blockedSpan).not.toBeNull();
+    });
+
+    it("handles undefined src in images", async () => {
+      const tree = await processMarkdown("![No src]()");
+
+      const blockedSpan = findSpanWithText(tree, "[Image blocked:");
+      expect(blockedSpan).not.toBeNull();
+    });
+
+    it("handles complex markdown with mixed allowed/blocked content", async () => {
+      const tree = await processMarkdown(
+        `
+# My Document
+
+This has [allowed link](https://github.com/repo) and [blocked link](https://bad.com).
+
+![Allowed image](https://via.placeholder.com/100)
+![Blocked image](https://external.com/img.jpg)
+
+> Quote with [another link](https://docs.github.com/)
+      `,
+        {
+          defaultOrigin: "https://example.com",
+          allowedLinkPrefixes: [
+            "https://github.com/",
+            "https://docs.github.com",
+          ],
+          allowedImagePrefixes: ["https://via.placeholder.com/"],
+        },
+      );
+
+      // Check allowed content
+      const links = findElements(tree, "a");
+      const imgs = findElements(tree, "img");
+
+      expect(links).toHaveLength(2);
+      expect(imgs).toHaveLength(1);
+
+      const hrefs = links.map((link) => link.properties.href);
+      expect(hrefs).toContain("https://github.com/repo");
+      expect(hrefs).toContain("https://docs.github.com/");
+
+      expect(imgs[0].properties.alt).toBe("Allowed image");
+
+      // Check blocked content
+      const blockedSpans = [
+        findSpanWithText(tree, "blocked link [blocked]"),
+        findSpanWithText(tree, "[Image blocked: Blocked image]"),
+      ];
+
+      blockedSpans.forEach((span) => expect(span).not.toBeNull());
+    });
+  });
+
+  describe("Image transformation with relative URLs", () => {
+    it("preserves query params and hash in relative image URLs", async () => {
+      const tree = await processMarkdown(
+        "![Test](/img.jpg?size=large&v=2#section)",
+        {
+          defaultOrigin: "https://trusted.com",
+          allowedImagePrefixes: ["https://trusted.com/"],
+        },
+      );
+
+      const img = findElement(tree, "img");
+      expect(img).not.toBeNull();
+      expect(img!.properties.src).toBe("/img.jpg?size=large&v=2#section");
+    });
+
+    it("blocks relative images when origin not allowed", async () => {
+      const tree = await processMarkdown("![Test](/evil.jpg)", {
+        defaultOrigin: "https://untrusted.com",
+        allowedImagePrefixes: ["https://trusted.com/"],
+      });
+
+      const img = findElement(tree, "img");
+      expect(img).toBeNull();
+
+      const blockedSpan = findSpanWithText(tree, "[Image blocked:");
+      expect(blockedSpan).not.toBeNull();
+    });
+  });
+
+  describe("Specific bypass attempts", () => {
+    it("correctly handles URLs that appear to bypass but actually resolve correctly", async () => {
+      const tree = await processMarkdown(
+        "![Test](https://trusted.com/../../../evil.com/image.jpg)",
+        {
+          defaultOrigin: "https://example.com",
+          allowedImagePrefixes: ["https://trusted.com/"],
+        },
+      );
+
+      const img = findElement(tree, "img");
+      expect(img).not.toBeNull();
+      expect(img!.properties.src).toBe(
+        "https://trusted.com/evil.com/image.jpg",
+      );
+    });
+
+    it("blocks images inside blocked links", async () => {
+      const tree = await processMarkdown(
+        '[![click](http://evil.com/img.png)](javascript:alert("nested-img-link"))',
+        {
+          defaultOrigin: "https://example.com",
+          allowedLinkPrefixes: ["https://example.com/", "https://trusted.org/"],
+          allowedImagePrefixes: ["https://example.com/", "https://images.com/"],
+        },
+      );
+
+      // The link should be blocked
+      const link = findElement(tree, "a");
+      expect(link).toBeNull();
+
+      // No img elements should exist (even the nested one should be blocked)
+      const img = findElement(tree, "img");
+      expect(img).toBeNull();
+
+      // Should have a blocked link span
+      const blockedLinkSpan = findSpanWithText(tree, "[blocked]");
+      expect(blockedLinkSpan).not.toBeNull();
+
+      // Should have a blocked image placeholder inside the blocked link
+      const blockedImageSpan = findSpanWithText(tree, "[Image blocked: click]");
+      expect(blockedImageSpan).not.toBeNull();
+    });
+
+    it("blocks nested images in complex blocked link structures", async () => {
+      const tree = await processMarkdown(
+        '[![![nested](javascript:alert("inner"))](https://safe.com)](javascript:alert("outer"))',
+        {
+          defaultOrigin: "https://example.com",
+          allowedLinkPrefixes: ["https://example.com/", "https://trusted.org/"],
+          allowedImagePrefixes: ["https://example.com/", "https://images.com/"],
+        },
+      );
+
+      // No links or images should exist
+      const link = findElement(tree, "a");
+      const img = findElement(tree, "img");
+      expect(link).toBeNull();
+      expect(img).toBeNull();
+
+      // Should have blocked content
+      const blockedLinkSpan = findSpanWithText(tree, "[blocked]");
+      expect(blockedLinkSpan).not.toBeNull();
+
+      // The nested image should also be blocked
+      const blockedImageSpan = findSpanWithText(
+        tree,
+        "[Image blocked: nested]",
+      );
+      expect(blockedImageSpan).not.toBeNull();
+    });
+
+    it.each([
+      "[Test](javascript:alert)",
+      "[Test](data:text)",
+      "[Test](vbscript:)",
+    ])(
+      "handles malformed URLs that contain invalid characters (%s)",
+      async (markdown) => {
+        const tree = await processMarkdown(markdown, {
+          defaultOrigin: "https://example.com",
+        });
+
+        // These should be blocked
+        const link = findElement(tree, "a");
+        expect(link).toBeNull();
+      },
+    );
+  });
+});
+
+describe("URL prefix validation behavior", () => {
+  it("requires complete valid URL prefixes (protocol-only prefixes don't work)", async () => {
+    const tree = await processMarkdown("[Test Link](https://github.com/test)", {
+      defaultOrigin: "https://example.com",
+      allowedLinkPrefixes: ["https://"],
+    });
+
+    // The link should be blocked because "https://" cannot be parsed as a valid URL
+    const link = findElement(tree, "a");
+    expect(link).toBeNull();
+
+    const blockedSpan = findSpanWithText(tree, "[blocked]");
+    expect(blockedSpan).not.toBeNull();
+  });
+
+  it("works with complete domain prefixes", async () => {
+    const tree = await processMarkdown(
+      "[Test Link](https://github.com/user/repo)",
+      {
+        defaultOrigin: "https://example.com",
+        allowedLinkPrefixes: ["https://github.com/"],
+      },
+    );
+
+    const link = findElement(tree, "a");
+    expect(link).not.toBeNull();
+    expect(link!.properties.href).toBe("https://github.com/user/repo");
+  });
+
+  it("requires origin and prefix to match for validation", async () => {
+    const tree = await processMarkdown(
+      "[Allowed](https://github.com/user/repo) [Blocked](https://github.com/other/repo)",
+      {
+        defaultOrigin: "https://example.com",
+        allowedLinkPrefixes: ["https://github.com/user/"],
+      },
+    );
+
+    // Only the first link should be rendered since it matches the prefix
+    const links = findElements(tree, "a");
+    expect(links).toHaveLength(1);
+    expect(getTextContent(links[0])).toBe("Allowed");
+    expect(links[0].properties.href).toBe("https://github.com/user/repo");
+
+    const blockedSpan = findSpanWithText(tree, "[blocked]");
+    expect(blockedSpan).not.toBeNull();
+  });
+});
+
+describe("Wildcard prefix support", () => {
+  it.each([
+    {
+      input: "https://example.com/test",
+      expected: "https://example.com/test",
+    },
+    {
+      input: "https://malicious-site.com/tracker",
+      expected: "https://malicious-site.com/tracker",
+    },
+    {
+      input: "http://insecure-site.com/",
+      expected: "http://insecure-site.com/",
+    },
+    {
+      input: "https://any-domain.org/path",
+      expected: "https://any-domain.org/path",
+    },
+  ])(
+    "allows all links when allowedLinkPrefixes includes '*' (input: $input, expected: $expected)",
+    async ({ input, expected }) => {
+      const tree = await processMarkdown(`[Test Link](${input})`, {
+        defaultOrigin: "https://example.com",
+        allowedLinkPrefixes: ["*"],
+      });
+
+      const link = findElement(tree, "a");
+      expect(link).not.toBeNull();
+      expect(link!.properties.href).toBe(expected);
+      expect(getTextContent(link!)).toBe("Test Link");
+    },
+  );
+
+  it.each([
+    "https://example.com/image.png",
+    "https://untrusted-site.com/tracker.gif",
+    "http://insecure-images.com/photo.jpg",
+    "https://any-cdn.net/asset.svg",
+  ])(
+    "allows all images when allowedImagePrefixes includes '*' (%s)",
+    async (url) => {
+      const tree = await processMarkdown(`![Test Image](${url})`, {
+        defaultOrigin: "https://example.com",
+        allowedImagePrefixes: ["*"],
+      });
+
+      const img = findElement(tree, "img");
+      expect(img).not.toBeNull();
+      expect(img!.properties.src).toBe(url);
+      expect(img!.properties.alt).toBe("Test Image");
+    },
+  );
+
+  it("handles relative URLs with wildcard prefix", async () => {
+    const tree1 = await processMarkdown("[Relative Link](/internal-page)", {
+      defaultOrigin: "https://example.com",
+      allowedLinkPrefixes: ["*"],
+    });
+
+    const link = findElement(tree1, "a");
+    expect(link).not.toBeNull();
+    expect(link!.properties.href).toBe("/internal-page");
+
+    const tree2 = await processMarkdown("![Relative Image](/images/logo.png)", {
+      defaultOrigin: "https://example.com",
+      allowedImagePrefixes: ["*"],
+    });
+
+    const img = findElement(tree2, "img");
+    expect(img).not.toBeNull();
+    expect(img!.properties.src).toBe("/images/logo.png");
+  });
+
+  it("wildcard works alongside other prefixes", async () => {
+    const tree = await processMarkdown(
+      "[Any Link](https://random-site.com/path)",
+      {
+        defaultOrigin: "https://example.com",
+        allowedLinkPrefixes: ["https://github.com/", "*"],
+      },
+    );
+
+    const link = findElement(tree, "a");
+    expect(link).not.toBeNull();
+    expect(link!.properties.href).toBe("https://random-site.com/path");
+  });
+
+  it("wildcard allows malformed URLs that can still be parsed", async () => {
+    const tree = await processMarkdown(
+      "[Test](//example.com/protocol-relative)",
+      {
+        defaultOrigin: "https://example.com",
+        allowedLinkPrefixes: ["*"],
+      },
+    );
+
+    const link = findElement(tree, "a");
+    expect(link).not.toBeNull();
+    expect(link!.properties.href).toBe("/protocol-relative");
+  });
+
+  it("wildcard allows URLs that can be resolved with defaultOrigin", async () => {
+    const tree = await processMarkdown("[Test](invalid-url-without-protocol)", {
+      defaultOrigin: "https://example.com",
+      allowedLinkPrefixes: ["*"],
+    });
+
+    // With defaultOrigin, this gets resolved to an absolute URL
+    const link = findElement(tree, "a");
+    expect(link).not.toBeNull();
+    expect(link!.properties.href).toBe(
+      "https://example.com/invalid-url-without-protocol",
+    );
+  });
+
+  it("wildcard doesn't require defaultOrigin for absolute URLs", async () => {
+    const tree = await processMarkdown("[Test](https://example.com/test)", {
+      allowedLinkPrefixes: ["*"],
+    });
+
+    const link = findElement(tree, "a");
+    expect(link).not.toBeNull();
+    expect(link!.properties.href).toBe("https://example.com/test");
+  });
+
+  it("wildcard still blocks completely unparseable URLs", async () => {
+    const tree = await processMarkdown("[Test](ht@tp://not-a-valid-url)", {
+      allowedLinkPrefixes: ["*"],
+    });
+
+    const link = findElement(tree, "a");
+    expect(link).toBeNull();
+
+    const blockedSpan = findSpanWithText(tree, "[blocked]");
+    expect(blockedSpan).not.toBeNull();
+  });
+
+  it("wildcard still blocks javascript: URLs", async () => {
+    const tree = await processMarkdown("[Test](javascript:alert('XSS'))", {
+      allowedLinkPrefixes: ["*"],
+    });
+
+    // Even with wildcard "*", javascript: URLs are blocked because they can't be parsed by URL()
+    const link = findElement(tree, "a");
+    expect(link).toBeNull();
+
+    const blockedSpan = findSpanWithText(tree, "[blocked]");
+    expect(blockedSpan).not.toBeNull();
+  });
+
+  it("wildcard blocks data: URLs", async () => {
+    const tree = await processMarkdown("[Test](data:text/html,123)", {
+      allowedLinkPrefixes: ["*"],
+    });
+
+    // Even with wildcard "*", data: URLs are blocked because they can't be parsed by URL()
+    const link = findElement(tree, "a");
+    expect(link).toBeNull();
+
+    const blockedSpan = findSpanWithText(tree, "[blocked]");
+    expect(blockedSpan).not.toBeNull();
+  });
+
+  it("wildcard still blocks javascript: URLs (with identity transform)", async () => {
+    const tree = await processMarkdown('[Test](javascript:alert("XSS"))', {
+      allowedLinkPrefixes: ["*"],
+    });
+
+    const link = findElement(tree, "a");
+    expect(link).toBeNull();
+
+    const blockedSpan = findSpanWithText(tree, "[blocked]");
+    expect(blockedSpan).not.toBeNull();
+  });
+
+  it("wildcard still blocks data: URLs (with identity transform)", async () => {
+    const tree = await processMarkdown("[Test](data:text/html,123)", {
+      allowedLinkPrefixes: ["*"],
+    });
+
+    const link = findElement(tree, "a");
+    expect(link).toBeNull();
+
+    const blockedSpan = findSpanWithText(tree, "[blocked]");
+    expect(blockedSpan).not.toBeNull();
+  });
+});

--- a/rehype-harden/tsconfig.json
+++ b/rehype-harden/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "lib": ["esnext", "DOM", "DOM.Iterable"],
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "allowJs": false,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "esnext",
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/rehype-harden/vitest.config.ts
+++ b/rehype-harden/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/*.d.ts"],
+    },
+    testTimeout: 30000, // 30 seconds for performance tests
+  },
+});


### PR DESCRIPTION
This adds a `rehype-harden` package that does everything that `harden-react-markdown` does, but is cross-platform-compatible (it's a drop-in rehype plugin). It also adds it to the `harden-react-markdown` package so the code can stay in one place.

There's some tidying-up stuff that needs to be done (it's installed via `file:` right now, needs a README, etc), but I figured I'd open the PR for review before investing significantly more time.