### PR TITLE
Add commonmark specific escaping for GitHub rendering

### DIFF
--- a/markdown-to-markdown-sanitizer/README.md
+++ b/markdown-to-markdown-sanitizer/README.md
@@ -149,6 +149,14 @@ interface SanitizeOptions {
    * Default is 100000 characters. 0 means no limit.
    */
   maxMarkdownLength?: number;
+
+  /**
+   * Activates sanization designed to be safe in commonmark.
+   * Notably, this is what Github uses and it is needed to avoid GitHub rendering HTML entities.
+   * The output is less encoded and relies heavier on the markdown parsing to be correct.
+   * Default is false.
+   */
+  sanitizeForCommonmark?: boolean;
 }
 ```
 

--- a/markdown-to-markdown-sanitizer/package.json
+++ b/markdown-to-markdown-sanitizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-to-markdown-sanitizer",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "description": "A robust markdown sanitizer that produces unambiguous and sanitized markdown output.",
   "type": "module",
   "main": "dist/index.js",

--- a/markdown-to-markdown-sanitizer/src/types.ts
+++ b/markdown-to-markdown-sanitizer/src/types.ts
@@ -31,4 +31,12 @@ export interface SanitizeOptions {
    * Without this, all relative URLs will be rejected for security.
    */
   defaultOrigin: string;
+  /**
+   * Activates sanization designed to be safe in commonmark.
+   * Notably, this is what Github uses.
+   * The output is less encoded and relies heavier on the markdown
+   * parsing to be correct.
+   * Default is false.
+   */
+  sanitizeForCommonmark?: boolean;
 }

--- a/markdown-to-markdown-sanitizer/tests/basic-sanitization-commonmark.test.ts
+++ b/markdown-to-markdown-sanitizer/tests/basic-sanitization-commonmark.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, test } from "vitest";
+import { MarkdownSanitizer } from "../src/index";
+
+describe("Basic Markdown Sanitization (CommonMark Escaper)", () => {
+  const createSanitizer = (options = {}) =>
+    new MarkdownSanitizer({
+      defaultOrigin: "https://example.com",
+      allowedLinkPrefixes: ["https://example.com", "https://trusted.org"],
+      allowedImagePrefixes: ["https://example.com", "https://images.com"],
+      sanitizeForCommonmark: true, // Enable CommonMark escaper
+      ...options,
+    });
+
+  const sanitize = (input: string, options = {}) => {
+    return createSanitizer(options).sanitize(input);
+  };
+
+  describe("Link Sanitization", () => {
+    test("allows trusted links", () => {
+      const input = "[Click here](https://example.com/page)";
+      const result = sanitize(input);
+      expect(result).toBe("[Click here](https://example.com/page)\n");
+    });
+
+    test("blocks untrusted links", () => {
+      const input = "[Malicious](https://evil.com/steal)";
+      const result = sanitize(input);
+      expect(result).toBe("[Malicious](#)\n");
+    });
+
+    test("handles relative links with default origin", () => {
+      const input = "[Relative](/path/to/page)";
+      const result = sanitize(input);
+      expect(result).toBe("[Relative](https://example.com/path/to/page)\n");
+    });
+
+    test("handles multiple links", () => {
+      const input =
+        "[Good](https://example.com/good) and [Bad](https://evil.com/bad)";
+      const result = sanitize(input);
+      expect(result).toBe("[Good](https://example.com/good) and [Bad](#)\n");
+    });
+
+    test("preserves link text even when URL is blocked", () => {
+      const input = '[Important Info](javascript:alert("xss"))';
+      const result = sanitize(input);
+      // javascript: URLs are completely stripped by DOMPurify, leaving just text
+      expect(result).toBe("Important Info\n");
+    });
+  });
+
+  describe("Image Sanitization", () => {
+    test("allows trusted images", () => {
+      const input = "![Alt text](https://images.com/photo.jpg)";
+      const result = sanitize(input);
+      expect(result).toBe("![](https://images.com/photo.jpg)\n");
+    });
+
+    test("blocks untrusted images", () => {
+      const input = "![Evil](https://evil.com/tracker.gif)";
+      const result = sanitize(input);
+      expect(result).toBe("![](/forbidden)\n");
+    });
+
+    test("handles relative image paths", () => {
+      const input = "![Local](/images/local.png)";
+      const result = sanitize(input);
+      expect(result).toBe("![](https://example.com/images/local.png)\n");
+    });
+
+    test("removes alt text when image is blocked", () => {
+      const input = "![Important Image](data:image/gif;base64,R0lGOD)";
+      const result = sanitize(input);
+      // data: URLs are sanitized to /forbidden, alt text is removed for security
+      expect(result).toBe("![](/forbidden)\n");
+    });
+  });
+
+  describe("Mixed Content", () => {
+    test("handles text with both links and images", () => {
+      const input = `# Title
+
+Here is a [link](https://example.com/page) and an image ![img](https://images.com/pic.jpg).
+
+Also a bad [link](https://evil.com) and bad ![image](https://evil.com/tracker.gif).`;
+
+      const result = sanitize(input);
+      // With CommonMark escaper, periods should be escaped as \.
+      expect(result).toBe(
+        "# Title\n\nHere is a [link](https://example.com/page) and an image ![](https://images.com/pic.jpg)\\.\n\nAlso a bad [link](#) and bad ![](/forbidden)\\.\n",
+      );
+    });
+  });
+
+  describe("Edge Cases", () => {
+    test("handles empty input", () => {
+      expect(sanitize("")).toBe("");
+    });
+
+    test("handles whitespace only", () => {
+      expect(sanitize("   \n   ")).toBe("");
+    });
+
+    test("handles plain text without markdown", () => {
+      const input = "Just plain text with no markdown.";
+      // With CommonMark escaper, period should be escaped
+      expect(sanitize(input)).toBe("Just plain text with no markdown\\.\n");
+    });
+
+    test("handles malformed markdown gracefully", () => {
+      const input =
+        "[Incomplete link without closing paren](https://example.com";
+      const result = sanitize(input);
+      expect(result).toBeTruthy(); // Should not crash
+    });
+
+    test("handles nested brackets", () => {
+      const input = "[[Nested] brackets](https://example.com)";
+      const result = sanitize(input);
+      // With CommonMark escaper, brackets should be escaped with backslashes
+      expect(result).toBe("[\\[Nested\\] brackets](https://example.com/)\n");
+    });
+
+    test("handles escaped characters", () => {
+      const input = "\\[Not a link\\] and \\![Not an image\\]";
+      const result = sanitize(input);
+      // CommonMark escaper should preserve valid escape sequences
+      expect(result).toBe("\\[Not a link\\] and \\!\\[Not an image\\]\n");
+    });
+  });
+
+  describe("URL Edge Cases", () => {
+    test("handles very long URLs", () => {
+      const longUrl = "https://example.com/" + "a".repeat(300);
+      const input = `[Link](${longUrl})`;
+      const result = sanitize(input);
+      expect(result).toBe("[Link](#)\n"); // Should be blocked due to length
+    });
+
+    test("handles URLs with special characters", () => {
+      const input =
+        "[Link](https://example.com/path?query=value&other=123#fragment)";
+      const result = sanitize(input);
+      // CommonMark escaper should handle URL encoding cleanly
+      expect(result).toBe(
+        "[Link](https://example.com/path?query=value&other=123#fragment)\n",
+      );
+    });
+
+    test("handles protocol-relative URLs", () => {
+      const input = "[Link](//example.com/path)";
+      const result = sanitize(input);
+      expect(result).toBe("[Link](https://example.com/path)\n");
+    });
+
+    test("rejects invalid URLs", () => {
+      const input = "[Link](not-a-valid-url)";
+      const result = sanitize(input);
+      expect(result).toBe("[Link](https://example.com/not-a-valid-url)\n");
+    });
+  });
+
+  describe("Reference Style Links", () => {
+    test("handles reference style links", () => {
+      const input = `[link text][ref]
+
+[ref]: https://example.com/page`;
+      const result = sanitize(input);
+      // Turndown converts reference links to inline links
+      expect(result).toBe(
+        "[link text](https://example.com/page)\n",
+      );
+    });
+
+    test("sanitizes reference URLs", () => {
+      const input = `[link text][ref]
+
+[ref]: https://evil.com/malicious`;
+      const result = sanitize(input);
+      // Blocked URLs get converted to # and turndown preserves inline format
+      expect(result).toBe("[link text](#)\n");
+    });
+  });
+
+  describe("CommonMark Escaping Behavior", () => {
+    test("processes markdown syntax through HTML pipeline", () => {
+      const input = "Text with *asterisks* and _underscores_ and #hash";
+      const result = sanitize(input);
+      // Markdown gets processed to HTML first, so emphasis becomes <em> tags
+      // When converted back, they become markdown emphasis again
+      expect(result).toBe("Text with *asterisks* and *underscores* and \\#hash\n");
+    });
+
+    test("preserves valid escape sequences", () => {
+      const input = "Already \\*escaped\\* content should remain \\*escaped\\*";
+      const result = sanitize(input);
+      expect(result).toBe("Already \\*escaped\\* content should remain \\*escaped\\*\n");
+    });
+
+    test("handles backslashes correctly", () => {
+      const input = "Single \\ backslash and double \\\\ backslash";
+      const result = sanitize(input);
+      // Single backslashes are treated as literals, double backslashes are preserved
+      expect(result).toBe("Single \\ backslash and double \\ backslash\n");
+    });
+
+    test("escapes CommonMark punctuation in text", () => {
+      // Test with punctuation that doesn't form valid markdown structures
+      const input = "Special chars: !\"#$%&'()+,-./:;<=>?@[]^`{|}~";
+      const result = sanitize(input);
+      // The CommonMark escaper uses backslash escaping for punctuation
+      expect(result).toBe("Special chars\\: \\!\\\"\\#\\$\\%\\&\\'\\(\\)\\+\\,\\-\\.\\/\\:\\;\\<\\=\\>\\?\\@\\[\\]\\^\\`\\{\\|\\}\\~\n");
+    });
+  });
+});

--- a/markdown-to-markdown-sanitizer/tests/bypass-attempts.test.ts
+++ b/markdown-to-markdown-sanitizer/tests/bypass-attempts.test.ts
@@ -121,6 +121,13 @@ describe("Markdown Sanitizer Bypass Attempts", () => {
       const parsed = parser.parse(markdown);
       return renderer.render(parsed);
     },
+
+    commonmarkWithCommonmarkEscape: async (markdown: string) => {
+      const parser = new CommonMarkParser();
+      const renderer = new HtmlRenderer({ safe: false });
+      const parsed = parser.parse(markdown);
+      return renderer.render(parsed);
+    },
   };
 
   const sanitizeAndRenderToHtml = async (
@@ -280,6 +287,8 @@ describe("Markdown Sanitizer Bypass Attempts", () => {
 
     const rendererNames = Object.keys(renderers);
 
+    let ranCommonMarkEscapeTest = false;
+
     files.forEach((file) => {
       describe(file, () => {
         rendererNames.forEach((rendererName) => {
@@ -287,10 +296,20 @@ describe("Markdown Sanitizer Bypass Attempts", () => {
             const filePath = path.join(bypassDir, file);
             const markdown = fs.readFileSync(filePath, "utf-8");
 
+            const sanitizeOptions =
+              rendererName === "commonmarkWithCommonmarkEscape"
+                ? { sanitizeForCommonmark: true }
+                : {};
+
+            if (sanitizeOptions.sanitizeForCommonmark) {
+              ranCommonMarkEscapeTest = true;
+            }
+
             // Sanitize and render to HTML using specific renderer
             const { html, sanitized } = await sanitizeAndRenderToHtml(
               markdown,
               rendererName,
+              sanitizeOptions,
             );
 
             // Validate the HTML
@@ -322,6 +341,9 @@ describe("Markdown Sanitizer Bypass Attempts", () => {
           });
         });
       });
+    });
+    test("should have run the commonmark escape test", () => {
+      expect(ranCommonMarkEscapeTest).toBe(true);
     });
   });
 

--- a/markdown-to-markdown-sanitizer/tests/code-blocks-commonmark.test.ts
+++ b/markdown-to-markdown-sanitizer/tests/code-blocks-commonmark.test.ts
@@ -1,0 +1,301 @@
+import { describe, expect, test } from "vitest";
+import { MarkdownSanitizer } from "../src/index";
+
+describe("Code Block Security and Functionality (CommonMark Escaper)", () => {
+  const sanitizer = new MarkdownSanitizer({
+    defaultOrigin: "https://example.com",
+    allowedLinkPrefixes: ["https://example.com", "https://github.com"],
+    allowedImagePrefixes: ["https://example.com/images"],
+    sanitizeForCommonmark: true, // Enable CommonMark escaper
+  });
+
+  describe("Inline code functionality", () => {
+    test("inline code with HTML should be preserved", () => {
+      const input = 'Use `<script>alert("test")</script>` in your code.';
+      const result = sanitizer.sanitize(input);
+
+      expect(result).toBe(
+        'Use `<script>alert("test")</script>` in your code\\.\n',
+      );
+    });
+
+    test("inline code with markdown syntax should be preserved", () => {
+      const input =
+        "The syntax is `![image](url)` for images and `[link](url)` for links.";
+      const result = sanitizer.sanitize(input);
+
+      expect(result).toBe(
+        "The syntax is `![image](url)` for images and `[link](url)` for links\\.\n",
+      );
+    });
+
+    test("inline code with dangerous protocols should be preserved", () => {
+      const input = 'Example: `<img src="javascript:alert()">` is dangerous.';
+      const result = sanitizer.sanitize(input);
+
+      expect(result).toBe(
+        'Example\\: `<img src="javascript:alert()">` is dangerous\\.\n',
+      );
+    });
+
+    test("inline code with quotes and special chars should be preserved", () => {
+      const input =
+        'Use `document.getElementById("test")` and `element.setAttribute("class", "active")`.';
+      const result = sanitizer.sanitize(input);
+
+      expect(result).toBe(
+        'Use `document.getElementById("test")` and `element.setAttribute("class", "active")`\\.\n',
+      );
+    });
+  });
+
+  describe("Fenced code block functionality", () => {
+    test("fenced code block with HTML should be preserved", () => {
+      const input = `Code example:
+
+\`\`\`html
+<script>
+  alert("This should not execute");
+  document.getElementById("test");
+</script>
+<img src="javascript:alert('xss')" onerror="alert('xss')">
+\`\`\`
+
+End of example.`;
+
+      const result = sanitizer.sanitize(input);
+
+      const expected = `Code example\\:
+
+\`\`\`html
+<script>
+  alert("This should not execute");
+  document.getElementById("test");
+</script>
+<img src="javascript:alert('xss')" onerror="alert('xss')">
+\`\`\`
+
+End of example\\.
+`;
+
+      expect(result).toBe(expected);
+    });
+
+    test("fenced code block with markdown syntax should be preserved", () => {
+      const input = `Markdown examples:
+
+\`\`\`markdown
+# Header
+![Dangerous image](javascript:alert('xss'))
+[Dangerous link](javascript:alert('xss'))
+<img src="x" onerror="alert('xss')">
+\`\`\`
+
+These are just examples.`;
+
+      const result = sanitizer.sanitize(input);
+
+      const expected = `Markdown examples\\:
+
+\`\`\`markdown
+# Header
+![Dangerous image](javascript:alert('xss'))
+[Dangerous link](javascript:alert('xss'))
+<img src="x" onerror="alert('xss')">
+\`\`\`
+
+These are just examples\\.
+`;
+
+      expect(result).toBe(expected);
+    });
+
+    test("fenced code block with mixed quotes and special chars", () => {
+      const input = `JavaScript example:
+
+\`\`\`javascript
+function dangerous() {
+  eval('alert("XSS")');
+  document.write('<img src="x" onerror="alert()">');
+  location.href = "javascript:alert('xss')";
+}
+\`\`\`
+
+Don't run this code.`;
+
+      const result = sanitizer.sanitize(input);
+
+      const expected = `JavaScript example\\:
+
+\`\`\`javascript
+function dangerous() {
+  eval('alert("XSS")');
+  document.write('<img src="x" onerror="alert()">');
+  location.href = "javascript:alert('xss')";
+}
+\`\`\`
+
+Don\\'t run this code\\.
+`;
+
+      expect(result).toBe(expected);
+    });
+  });
+
+  describe("Indented code block functionality", () => {
+    test("indented code block with HTML should be preserved", () => {
+      const input = `Example:
+
+    <script>alert('xss')</script>
+    <img src="javascript:alert()" onerror="alert()">
+
+End of code.`;
+
+      const result = sanitizer.sanitize(input);
+
+      const expected = `Example\\:
+
+\`\`\`
+<script>alert('xss')</script>
+<img src="javascript:alert()" onerror="alert()">
+\`\`\`
+
+End of code\\.
+`;
+
+      expect(result).toBe(expected);
+    });
+  });
+
+  describe("Mixed code and non-code content", () => {
+    test("code blocks should not affect surrounding markdown", () => {
+      const input = `Here is safe content with [a link](https://example.com).
+
+\`\`\`html
+<script>alert('This is in code')</script>
+\`\`\`
+
+And here is more safe content with **bold text**.
+
+Inline code: \`<img src="x" onerror="alert()">\` in text.
+
+Final [link](https://example.com) here.`;
+
+      const result = sanitizer.sanitize(input);
+
+      const expected = `Here is safe content with [a link](https://example.com/)\\.
+
+\`\`\`html
+<script>alert('This is in code')</script>
+\`\`\`
+
+And here is more safe content with **bold text**\\.
+
+Inline code\\: \`<img src="x" onerror="alert()">\` in text\\.
+
+Final [link](https://example.com/) here\\.
+`;
+
+      expect(result).toBe(expected);
+    });
+
+    test("dangerous content outside code blocks should be sanitized", () => {
+      const input = `Code example:
+
+\`\`\`html
+<script>alert('safe in code')</script>
+\`\`\`
+
+But this should be sanitized: <script>alert('dangerous')</script>
+
+And this: ![bad](javascript:alert('xss'))`;
+
+      const result = sanitizer.sanitize(input);
+
+      const expected = `Code example\\:
+
+\`\`\`html
+<script>alert('safe in code')</script>
+\`\`\`
+
+But this should be sanitized\\:
+
+And this\\:
+`;
+
+      expect(result).toBe(expected);
+    });
+  });
+
+  describe("CommonMark Escaping in Code Context", () => {
+    test("special characters in text around code blocks are escaped", () => {
+      const input = `Special chars: !@#$%^&*()
+
+\`\`\`
+Code content stays untouched: !@#$%^&*()
+\`\`\`
+
+More special chars: []{}|\\~`;
+
+      const result = sanitizer.sanitize(input);
+
+      const expected = `Special chars\\: \\!\\@\\#\\$\\%\\^\\&\\*\\(\\)
+
+\`\`\`
+Code content stays untouched: !@#$%^&*()
+\`\`\`
+
+More special chars\\: \\[\\]\\{\\}\\|\\~
+`;
+
+      expect(result).toBe(expected);
+    });
+
+    test("backslashes in text are handled correctly", () => {
+      const input = `Backslash examples: \\ and \\\\
+
+\`\`\`
+Code: \\ and \\\\
+\`\`\`
+
+End with backslash: \\`;
+
+      const result = sanitizer.sanitize(input);
+
+      // Backslashes in text are preserved as literals when they don't form valid escapes
+      const expected = `Backslash examples\\: \\ and \\
+
+\`\`\`
+Code: \\ and \\\\
+\`\`\`
+
+End with backslash\\: \\
+`;
+
+      expect(result).toBe(expected);
+    });
+
+    test("preserves already escaped sequences in text", () => {
+      const input = `Already escaped \\*text\\* and \\[brackets\\]
+
+\`\`\`
+Code with \\*asterisks\\* and \\[brackets\\]
+\`\`\`
+
+More escaped \\#hash and \\>quote`;
+
+      const result = sanitizer.sanitize(input);
+
+      const expected = `Already escaped \\*text\\* and \\[brackets\\]
+
+\`\`\`
+Code with \\*asterisks\\* and \\[brackets\\]
+\`\`\`
+
+More escaped \\#hash and \\>quote
+`;
+
+      expect(result).toBe(expected);
+    });
+  });
+});

--- a/markdown-to-markdown-sanitizer/tests/commonmark-escape.test.ts
+++ b/markdown-to-markdown-sanitizer/tests/commonmark-escape.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from "vitest";
+import { commonmarkEscape } from "../src/index.js";
+
+describe("commonmarkEscape Function", () => {
+  describe("Basic Character Escaping", () => {
+    test("escapes single special characters", () => {
+      expect(commonmarkEscape("!")).toBe("\\!");
+      expect(commonmarkEscape("#")).toBe("\\#");
+      expect(commonmarkEscape("*")).toBe("\\*");
+      expect(commonmarkEscape("[")).toBe("\\[");
+      expect(commonmarkEscape("]")).toBe("\\]");
+      expect(commonmarkEscape("`")).toBe("\\`");
+      expect(commonmarkEscape("_")).toBe("\\_");
+      expect(commonmarkEscape("~")).toBe("\\~");
+    });
+
+    test("escapes all CommonMark punctuation characters", () => {
+      const punctuation = "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~";
+      const result = commonmarkEscape(punctuation);
+      // Each character should be escaped
+      expect(result).toBe("\\!\\\"\\#\\$\\%\\&\\'\\(\\)\\*\\+\\,\\-\\.\\/" +
+                         "\\:\\;\\<\\=\\>\\?\\@\\[\\]\\^\\_\\`\\{\\|\\}\\~");
+    });
+
+    test("leaves regular text unchanged", () => {
+      expect(commonmarkEscape("hello world")).toBe("hello world");
+      expect(commonmarkEscape("ABC123")).toBe("ABC123");
+      expect(commonmarkEscape("spaces and words")).toBe("spaces and words");
+    });
+
+    test("preserves spaces and newlines", () => {
+      expect(commonmarkEscape("text with spaces")).toBe("text with spaces");
+      expect(commonmarkEscape("line1\nline2")).toBe("line1\nline2");
+      expect(commonmarkEscape("  leading spaces")).toBe("  leading spaces");
+      expect(commonmarkEscape("trailing spaces  ")).toBe("trailing spaces  ");
+    });
+  });
+
+  describe("Backslash Handling", () => {
+    test("handles double backslashes (escaped backslash)", () => {
+      expect(commonmarkEscape("\\\\")).toBe("\\\\");
+      expect(commonmarkEscape("text\\\\more")).toBe("text\\\\more");
+      expect(commonmarkEscape("\\\\\\\\")).toBe("\\\\\\\\"); // Four backslashes stay as four
+    });
+
+    test("preserves valid escape sequences", () => {
+      expect(commonmarkEscape("\\*")).toBe("\\*"); // Already escaped asterisk
+      expect(commonmarkEscape("\\!")).toBe("\\!"); // Already escaped exclamation
+      expect(commonmarkEscape("\\#")).toBe("\\#"); // Already escaped hash
+      expect(commonmarkEscape("\\[")).toBe("\\["); // Already escaped bracket
+    });
+
+    test("handles backslash before non-escapable characters", () => {
+      expect(commonmarkEscape("\\a")).toBe("\\a"); // Backslash before 'a' stays literal
+      expect(commonmarkEscape("\\1")).toBe("\\1"); // Backslash before digit stays literal
+      expect(commonmarkEscape("\\z")).toBe("\\z"); // Backslash before letter stays literal
+      expect(commonmarkEscape("\\ ")).toBe("\\ "); // Backslash before space stays literal
+    });
+
+    test("handles backslash at end of string", () => {
+      expect(commonmarkEscape("text\\")).toBe("text\\");
+    });
+
+    test("handles complex backslash sequences", () => {
+      expect(commonmarkEscape("\\\\*")).toBe("\\\\\\*"); // Escaped backslash + asterisk that needs escaping
+      expect(commonmarkEscape("\\\\\\*")).toBe("\\\\\\*"); // Escaped backslash + already escaped asterisk
+      expect(commonmarkEscape("*\\\\")).toBe("\\*\\\\"); // Asterisk + escaped backslash
+    });
+  });
+
+  describe("Mixed Content", () => {
+    test("handles text with mixed special characters", () => {
+      expect(commonmarkEscape("Hello *world* with `code`")).toBe("Hello \\*world\\* with \\`code\\`");
+      expect(commonmarkEscape("# Header")).toBe("\\# Header");
+      expect(commonmarkEscape("[link](url)")).toBe("\\[link\\]\\(url\\)");
+    });
+
+    test("handles already partially escaped content", () => {
+      expect(commonmarkEscape("\\*bold* text")).toBe("\\*bold\\* text");
+      expect(commonmarkEscape("Some \\# heading")).toBe("Some \\# heading");
+    });
+
+    test("handles complex markdown syntax", () => {
+      expect(commonmarkEscape("![image](url)")).toBe("\\!\\[image\\]\\(url\\)");
+      expect(commonmarkEscape("**bold** and _italic_")).toBe("\\*\\*bold\\*\\* and \\_italic\\_");
+      expect(commonmarkEscape("> quote")).toBe("\\> quote");
+    });
+  });
+
+  describe("Edge Cases", () => {
+    test("handles empty string", () => {
+      expect(commonmarkEscape("")).toBe("");
+    });
+
+    test("handles single characters", () => {
+      expect(commonmarkEscape("a")).toBe("a");
+      expect(commonmarkEscape("*")).toBe("\\*");
+      expect(commonmarkEscape("\\")).toBe("\\");
+    });
+
+    test("handles strings with only special characters", () => {
+      expect(commonmarkEscape("***")).toBe("\\*\\*\\*");
+      expect(commonmarkEscape("###")).toBe("\\#\\#\\#");
+      expect(commonmarkEscape("---")).toBe("\\-\\-\\-");
+    });
+
+    test("handles unicode and non-ASCII characters", () => {
+      expect(commonmarkEscape("café")).toBe("café"); // Non-ASCII letters unchanged
+      expect(commonmarkEscape("Hello 世界")).toBe("Hello 世界"); // Unicode unchanged
+      expect(commonmarkEscape("emoji 🚀 *test*")).toBe("emoji 🚀 \\*test\\*");
+    });
+
+    test("handles very long strings", () => {
+      const longString = "a".repeat(1000) + "*" + "b".repeat(1000);
+      const expected = "a".repeat(1000) + "\\*" + "b".repeat(1000);
+      expect(commonmarkEscape(longString)).toBe(expected);
+    });
+  });
+
+  describe("CommonMark Specification Compliance", () => {
+    test("handles example cases from CommonMark spec", () => {
+      // Based on CommonMark spec examples
+      expect(commonmarkEscape("\\!\\\"\\#\\$\\%\\&\\'\\(\\)\\*\\+\\,\\-\\.\\/" +
+                              "\\:\\;\\<\\=\\>\\?\\@\\[\\\\\\]\\^\\_\\`\\{\\|\\}\\~"))
+        .toBe("\\!\\\"\\#\\$\\%\\&\\'\\(\\)\\*\\+\\,\\-\\.\\/" +
+              "\\:\\;\\<\\=\\>\\?\\@\\[\\\\\\]\\^\\_\\`\\{\\|\\}\\~");
+    });
+
+    test("preserves already properly escaped sequences", () => {
+      const input = "This is \\*not emphasis\\*, and \\<br/\\> is not a tag.";
+      expect(commonmarkEscape(input)).toBe("This is \\*not emphasis\\*\\, and \\<br\\/\\> is not a tag\\.");
+    });
+
+    test("handles nested escaping scenarios", () => {
+      expect(commonmarkEscape("\\\\\\*")).toBe("\\\\\\*"); // Escaped backslash + escaped asterisk
+      expect(commonmarkEscape("\\\\*")).toBe("\\\\\\*"); // Escaped backslash + unescaped asterisk
+    });
+  });
+});


### PR DESCRIPTION
It turns out that GitHub does not render all HTML entities inside of markdown text.

Instead we introduce a special commonmark escape mode that uses backslash escaping. Unfortunately, this does NOT work for other markdown parsers.

To verify this is secure, we run the bypass tests with the new option.